### PR TITLE
TOPS-993/feat/add-push-notifications-methods

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     ext.kotlin_version = '1.8.22'
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -17,7 +17,7 @@ buildscript {
 rootProject.allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
         maven { url 'https://zendesk.jfrog.io/zendesk/repo' }
     }
 }
@@ -43,8 +43,8 @@ dependencies {
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'androidx.appcompat:appcompat:1.2.0'
-    implementation group: 'com.zendesk', name: 'chat', version: '3.3.7'
-    implementation group: 'com.zendesk', name: 'messaging', version: '5.3.0'
-    implementation group: 'com.zendesk', name: 'chat-providers', version: '3.3.7'
+    implementation group: 'com.zendesk', name: 'chat', version: '3.4.0'
+    implementation group: 'com.zendesk', name: 'messaging', version: '5.4.0'
+    implementation group: 'com.zendesk', name: 'chat-providers', version: '3.4.0'
     implementation 'com.squareup.okhttp3:okhttp:4.10.0'
 }

--- a/android/src/main/kotlin/com/muljin/zendesk/ZendeskHelper.kt
+++ b/android/src/main/kotlin/com/muljin/zendesk/ZendeskHelper.kt
@@ -90,6 +90,10 @@ class ZendeskHelper : FlutterPlugin, MethodCallHandler, ActivityAware {
                     result.success(true)
                 }
 
+                "registerPushToken" -> {
+                    registerPushToken(call, result)
+                }
+
                 else -> {
                     result.notImplemented()
                 }
@@ -192,5 +196,23 @@ class ZendeskHelper : FlutterPlugin, MethodCallHandler, ActivityAware {
                 .withEngines(ChatEngine.engine())
                 .show(activity, chatConfiguration)
 
+    }
+
+    private fun registerPushToken(call: MethodCall, flutterResult: Result) {
+        val pushToken = call.argument<String>("pushToken")
+        if(pushToken == null) {
+            flutterResult.error("registerPushToken", "pushToken is required", null)
+            return
+        }
+
+        val pushProvider = Chat.INSTANCE.providers()?.pushNotificationsProvider()
+
+        if(pushProvider == null) {
+            flutterResult.error("registerPushToken", "pushProvider is null", null)
+            return
+        }
+
+        pushProvider.registerPushToken(pushToken)
+        flutterResult.success(true)
     }
 }

--- a/lib/zendesk_helper.dart
+++ b/lib/zendesk_helper.dart
@@ -101,4 +101,10 @@ class Zendesk {
   Future<void> sendMessage(String message) async {
     await _channel.invokeMethod<void>('sendMessage', {'message': message});
   }
+  /// Registers FCM's token for the device
+  Future<void> registerPushToken(String pushToken) async {
+    await _channel.invokeMethod<void>('registerPushToken', {
+      'pushToken': pushToken,
+    });
+  }
 }


### PR DESCRIPTION
This PR updates the dependencies and for android only:

- added method registerPushToken that registers an FCM token so Zendesk can send push notifications