### PR TITLE
Handle 'namespace' property for new Android Gradle plugin versions

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -26,7 +26,11 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 33
+    // Handle 'namespace' property for new Android Gradle plugin versions
+    if (project.hasProperty("android") && project.android.hasProperty("namespace")) {
+        namespace = "com.muljin.zendesk"
+    }
+    compileSdkVersion 34
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -38,6 +38,14 @@ android {
     defaultConfig {
         minSdkVersion 21
     }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
     lintOptions {
         disable 'InvalidPackage'
     }


### PR DESCRIPTION
This handle is required to use the library with the new Android Gradle versions.